### PR TITLE
Added stub ERC20 Trait, structs and example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
+ethnum = { version = "1", features = ["serde"] }
 serde = "1.0.171"
 serde_derive = "1.0.171"
 serde_json = "1.0.103"

--- a/examples/erc20.rs
+++ b/examples/erc20.rs
@@ -1,0 +1,53 @@
+use anyhow::Error;
+use ethnum::{uint, U256};
+use versatus_rust::versatus_rust::{process_erc20, Address, Erc20};
+
+struct ComputeUnitToken {}
+
+const COMPUTE_NAME: &str = "Compute Unit";
+const COMPUTE_SYMBOL: &str = "COUN";
+const COMPUTE_DECIMALS: u8 = 6;
+const COMPUTE_SUPPLY: U256 = uint!("0xffff_ffff_ffff_ffff");
+
+impl Erc20 for ComputeUnitToken {
+    fn name(&self) -> Result<String, Error> {
+        Ok(COMPUTE_NAME.to_string())
+    }
+
+    fn symbol(&self) -> Result<String, Error> {
+        Ok(COMPUTE_SYMBOL.to_string())
+    }
+
+    fn decimals(&self) -> Result<u8, Error> {
+        Ok(COMPUTE_DECIMALS)
+    }
+
+    fn total_supply(&self) -> Result<U256, Error> {
+        Ok(COMPUTE_SUPPLY)
+    }
+
+    fn balance_of(&self, _owner: Address) -> Result<U256, Error> {
+        Ok(uint!("0"))
+    }
+
+    fn transfer(&self, _to: Address, _value: U256) -> Result<bool, Error> {
+        Ok(true)
+    }
+
+    fn transfer_from(&self, _from: Address, _to: Address, _value: U256) -> Result<bool, Error> {
+        Ok(true)
+    }
+
+    fn approve(&self, _spender: Address, _value: U256) -> Result<bool, Error> {
+        Ok(true)
+    }
+
+    fn allowance(&self, _owner: Address, _spender: Address) -> Result<U256, Error> {
+        Ok(uint!("0"))
+    }
+}
+
+fn main() {
+    let token = ComputeUnitToken {};
+    process_erc20(&token).unwrap();
+}

--- a/src/versatus_rust.rs
+++ b/src/versatus_rust.rs
@@ -1,4 +1,5 @@
-use anyhow::Result;
+use anyhow::{Error, Result};
+use ethnum::U256;
 use serde_derive::{Deserialize, Serialize};
 use std::io::{self, Read, Write};
 
@@ -75,4 +76,65 @@ impl ComputeOutputs {
     pub fn commit(&self) -> Result<()> {
         Ok(io::stdout().write_all(serde_json::to_string(&self)?.as_bytes())?)
     }
+}
+
+// ERC20 related structures and interfaces
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Address {
+    pub bytes: [u8; 20],
+}
+
+/// An interface for ERC20 contracts to conform to.
+pub trait Erc20 {
+    /// Optional. Token name.
+    fn name(&self) -> Result<String, Error>;
+    /// Optional. Token ticker symbol.
+    fn symbol(&self) -> Result<String, Error>;
+    /// Optional. Returns the number of decimals the token uses - e.g. 8, means to divide the token amount by
+    /// 100000000 to get its user representation.
+    fn decimals(&self) -> Result<u8, Error>;
+    /// Returns the total token supply.
+    fn total_supply(&self) -> Result<U256, Error>;
+    /// Returns the account balance of another account with address [owner].
+    fn balance_of(&self, owner: Address) -> Result<U256, Error>;
+    /// Transfers _value amount of tokens to address _to, and MUST fire the Transfer event.
+    /// The function SHOULD throw if the message caller’s account balance does not have enough tokens to spend.
+    fn transfer(&self, to: Address, value: U256) -> Result<bool, Error>;
+    /// Transfers _value amount of tokens from address _from to address _to, and MUST fire the Transfer event.
+    ///
+    /// The transferFrom method is used for a withdraw workflow, allowing contracts to transfer tokens on
+    /// your behalf. This can be used for example to allow a contract to transfer tokens on your behalf
+    /// and/or to charge fees in sub-currencies. The function SHOULD throw unless the _from account has
+    /// deliberately authorized the sender of the message via some mechanism.
+    ///
+    /// Note Transfers of 0 values MUST be treated as normal transfers and fire the Transfer event.
+    fn transfer_from(&self, from: Address, to: Address, value: U256) -> Result<bool, Error>;
+    /// Allows _spender to withdraw from your account multiple times, up to the _value amount. If this
+    /// function is called again it overwrites the current allowance with _value.
+    ///
+    /// NOTE: To prevent attack vectors like the one described here and discussed here, clients SHOULD make
+    /// sure to create user interfaces in such a way that they set the allowance first to 0 before setting
+    /// it to another value for the same spender. THOUGH The contract itself shouldn’t enforce it, to
+    /// allow backwards compatibility with contracts deployed before.
+    fn approve(&self, spender: Address, value: U256) -> Result<bool, Error>;
+    /// Returns the amount which _spender is still allowed to withdraw from _owner.
+    fn allowance(&self, owner: Address, spender: Address) -> Result<U256, Error>;
+}
+
+pub struct Erc20TransferEvent {
+    pub from: Address,
+    pub to: Address,
+    pub value: U256,
+}
+
+pub struct Erc20ApprovalEvent {
+    pub owner: Address,
+    pub spender: Address,
+    pub value: U256,
+}
+
+pub fn process_erc20<T: Erc20>(t: &T) -> Result<bool, Error> {
+    println!("{}: {}", t.symbol()?, t.name()?);
+    println!("Supply: {}", t.total_supply()?);
+    Ok(true)
 }


### PR DESCRIPTION
This is just an initial stab at an interface for ERC20 tokens in Rust. It still needs to be plugged into the inputs and outputs stuff, but should give @milideva and @hathbanger a bit of an idea of what we're adding to the Rust SDK -- we'll be looking to do the same sort of thing with each language.

It's just stubs for now. I'll fill it in over the coming days.