### PR TITLE
Add `.cargo/config.toml` & update readme

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-wasi"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cargo build --release --example contract-split-evenly
 ```
 
 We declared target to be set to `wasm32-wasi` by default in the `.cargo` crate; inside you'll find `config.toml` which you can copy if you'd like to do the same.
-Otherwise it will be necessary to call `--target wasm32-wasi` at the end any build commands.
+Otherwise it will be necessary to call `--target wasm32-wasi` at the end of of any build commands.
 
 If you don't already have the `wasm32-wasi` Rust target installed, you can install it with `rustup`.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Build the sample with:
 cargo build --release --example contract-split-evenly
 ```
 
+We declared target to be set to `wasm32-wasi` by default in the `.cargo` crate; inside you'll find `config.toml` which you can copy if you'd like to do the same.
+Otherwise it will be necessary to call `--target wasm32-wasi` at the end any build commands.
+
 If you don't already have the `wasm32-wasi` Rust target installed, you can install it with `rustup`.
 
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ That said...
 Build the sample with:
 
 ```
-cargo build --release --example contract-split-evenly --target wasm32-wasi
+cargo build --release --example contract-split-evenly
 ```
 
 If you don't already have the `wasm32-wasi` Rust target installed, you can install it with `rustup`.


### PR DESCRIPTION
Added in a `config.toml` file for ease of access when it comes to running any `wasm32-wasi` executable.

This update relieves the need to add `--target wasm32-wasi` at the end of the build line.